### PR TITLE
Fix compilation with clang 3.5

### DIFF
--- a/mtrace.c
+++ b/mtrace.c
@@ -916,11 +916,15 @@ void fixup_stats(struct resp_buf *base, struct resp_buf *prev, struct resp_buf *
     int *r = reset + rno;
     int *s = swaps + rno;
     int res;
+    int nn;
+    int np;
 
     /* Check for byte-swappers */
     while (--rno >= 0) {
 	--n; --p; --b; --s;
-	if (*s || abs(ntohl(n->tr_vifout) - ntohl(p->tr_vifout)) > 100000) {
+	nn = ntohl(n->tr_vifout);
+	np = ntohl(p->tr_vifout);
+	if (*s || abs(nn - np) > 100000) {
 	    /* This host sends byteswapped reports; swap 'em */
 	    if (!*s) {
 		*s = 1;


### PR DESCRIPTION
clang 3.5 add a new check regarding unsigned_int used in abs(): This dirty hack prevent clang 3.5 to complains about.