### PR TITLE
DVMRP report missing subnet

### DIFF
--- a/route.c
+++ b/route.c
@@ -1193,7 +1193,7 @@ static int report_chunk(int which_routes, struct rtentry *start_rt, vifi_t vifi,
 
     p = send_buf + MIN_IP_HEADER_LEN + IGMP_MINLEN;
 
-    for (r = start_rt; r != routing_table; r = r->rt_prev) {
+    for (r = start_rt; r != NULL; r = r->rt_prev) {
 	if (which_routes == CHANGED_ROUTES && !(r->rt_flags & RTF_CHANGED)) {
 	    nrt++;
 	    continue;


### PR DESCRIPTION
A subnet is missing in the DVMRP report sent to it's neighbor after
the initial probe occurs.  The issue was with the traversal of a double
linked list from end to start. Once the traversing pointer reaches
the start of routing table for loop (condition) it would break and
always drop the first subnet.

Signed-off-by: Matthew Weber <matthew.weber@rockwellcollins.com>