### PR TITLE
New option to tune startup delay

### DIFF
--- a/defs.h
+++ b/defs.h
@@ -163,6 +163,8 @@ extern int		missingok;
 #define	DEBUG_ICMP	0x2000
 
 #define	DEFAULT_DEBUG	0x02de	/* default if "-d" given without value */
+#define DEFAULT_STARTUP_DELAY 10  /* default startup delay before forwarding in seconds */
+#define DSD_STRING           "10" /* same, as string */
 
 extern int		debug;
 extern int		did_final_init;

--- a/main.c
+++ b/main.c
@@ -488,7 +488,6 @@ int main(int argc, char *argv[])
      * do a report_to_all_neighbors(ALL_ROUTES) immediately before
      * turning on DVMRP.
      */
-printf("Applying startup delay %d\n", startupdelay);
     timer_setTimer(startupdelay, final_init, NULL);
 
     /*

--- a/mrouted.8
+++ b/mrouted.8
@@ -100,6 +100,11 @@ explicitly enabled with
 .Cm phyint enable
 in
 .Pa /etc/mrouted.conf
+.It Fl D, -startup-delay=DELAY
+Wait for DELAY seconds before applying the routes. This delay enables
+to exchange routes before starting to forward multicast packets and
+therefore eliminate transient problems at startup, at the cost of a
+momentary black hole. Defaults to 10 seconds.
 .It Fl f, -foreground
 Run in foreground, do not detach from the calling terminal.
 .It Fl c, -config=FILE


### PR DESCRIPTION
This pull request introduces a new option to `mrouted` daemon

`   --startup-delay=`_DELAY_

or

`   -D` _DELAY_

that defaults to 10 seconds and that enables to set up the previously hardcoded to 10 seconds delay before applying the new routes.

I tested it with a very simple setup `host -- router -- host` where both hosts try to join the same multicast group. It **has not been tested** with more complicated setups, with several routers, where DVMRP protocol would start playing its role.

However, with this simple setup, it proved to work, even when setting the delay to 0 (which is equivalent to disabling the wait phase at startup): the router immediately applies the routes it got from IGMP.
