### PR TITLE
[WIP] Add manual reload functionality to mrouted for hotplugged network interfaces

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -215,7 +215,13 @@ static void reload_gone_vifs(void)
             }
         }
         if (!found) {
-            stop_vif(find_vifi(uv));
+			vifi_t vifi = find_vifi(uv);
+			if (vifi == NO_VIF) {
+                TAILQ_REMOVE(&vifs, uv, uv_link);
+                free(uv);
+                continue;
+            }
+            stop_vif(vifi);
             uninstall_uvif(uv);
         }
     }
@@ -242,7 +248,8 @@ static void reload_new_vifs(void)
                 free(nuv);
                 continue;
             }
-            start_vif(find_vifi(nuv));
+			init_installvif(nuv, vifi);
+			start_vif2(vifi);
         }
     }
 }

--- a/src/defs.h
+++ b/src/defs.h
@@ -257,6 +257,7 @@ extern int              debug_list(int, char *, size_t);
 extern int              debug_parse(char *);
 extern void             restart(void);
 extern void             reload_iface(void);
+extern void             reload_vifs(void);
 extern char *		scaletime(time_t);
 extern int		register_input_handler(int, ihfunc_t);
 extern void		deregister_input_handler(int);
@@ -318,11 +319,14 @@ extern void		dump_routes(FILE *, int);
 
 /* vif.c */
 extern void		init_vifs(void);
+extern void     start_vif(vifi_t);
+extern void     stop_vif(vifi_t);
 extern void		blaster_alloc(struct uvif *);
 extern void		blaster_free(struct uvif *);
 extern void		zero_vif(struct uvif *, int);
 extern void		init_installvifs(void);
 extern int		install_uvif(struct uvif *);
+extern int      uninstall_uvif(struct uvif *);
 extern void		check_vif_state(void);
 extern void		send_on_vif(struct uvif *, uint32_t, int, size_t);
 extern struct uvif     *find_uvif(vifi_t);
@@ -358,6 +362,7 @@ extern struct uvif     *config_find_ifaddr(in_addr_t addr);
 extern struct uvif     *config_init_tunnel(in_addr_t lcl_addr, in_addr_t rmt_addr, uint32_t flags);
 extern void		config_vifs_correlate(void);
 extern void		config_vifs_from_kernel(void);
+extern void     config_vifs_from_reload(void);
 
 /* cfparse.y */
 extern void		config_vifs_from_file(void);

--- a/src/defs.h
+++ b/src/defs.h
@@ -313,13 +313,14 @@ extern void		report_to_all_neighbors(int);
 extern int		report_next_chunk(void);
 extern void		add_vif_to_routes(vifi_t);
 extern void		delete_vif_from_routes(vifi_t);
+extern void		discard_vif_from_routes(vifi_t);
 extern void		add_neighbor_to_routes(vifi_t, uint32_t);
 extern void		delete_neighbor_from_routes(uint32_t, vifi_t, uint32_t);
 extern void		dump_routes(FILE *, int);
 
 /* vif.c */
 extern void		init_vifs(void);
-extern void     start_vif(vifi_t);
+extern void     start_vif2(vifi_t);
 extern void     stop_vif(vifi_t);
 extern void		blaster_alloc(struct uvif *);
 extern void		blaster_free(struct uvif *);

--- a/src/defs.h
+++ b/src/defs.h
@@ -256,6 +256,7 @@ extern int		mrt_table_id;
 extern int              debug_list(int, char *, size_t);
 extern int              debug_parse(char *);
 extern void             restart(void);
+extern void             reload_iface(void);
 extern char *		scaletime(time_t);
 extern int		register_input_handler(int, ihfunc_t);
 extern void		deregister_input_handler(int);
@@ -452,6 +453,7 @@ extern int		pidfile(const char *basename);
 #define IPC_SHOW_MFC_CMD          21
 #define IPC_SHOW_NEIGH_CMD        22
 #define IPC_SHOW_ROUTES_CMD       23
+#define IPC_RELOAD_IFACE_CMD      30
 #define IPC_SHOW_COMPAT_CMD       250
 #define IPC_EOF_CMD               254
 #define IPC_ERR_CMD               255

--- a/src/ipc.c
+++ b/src/ipc.c
@@ -618,6 +618,10 @@ static void ipc_handle(int sd)
 		restart();
 		break;
 
+	case IPC_RELOAD_IFACE_CMD:
+		reload_iface();
+		break;
+
 	case IPC_DEBUG_CMD:
 		ipc_generic(client, &msg, do_debug, &msg);
 		break;

--- a/src/main.c
+++ b/src/main.c
@@ -504,8 +504,8 @@ int main(int argc, char *argv[])
     }
 
     logit(LOG_NOTICE, 0, "%s exiting", versionstring);
-    free(pfd);
     cleanup();
+	free(pfd);
 
     return 0;
 }

--- a/src/main.c
+++ b/src/main.c
@@ -504,8 +504,8 @@ int main(int argc, char *argv[])
     }
 
     logit(LOG_NOTICE, 0, "%s exiting", versionstring);
-    cleanup();
 	free(pfd);
+    cleanup();
 
     return 0;
 }

--- a/src/main.c
+++ b/src/main.c
@@ -811,40 +811,11 @@ void reload_iface(void)
     FILE *fp = NULL;
     char *s = NULL;
 
-    s = strdup (" reload");
+    s = strdup (" reload ifaces");
     if (s == NULL)
 	logit(LOG_ERR, 0, "out of memory");
 
-    /*
-     * reset all the entries, except routes and prunes
-     */
-    timer_stop_all();
-    stop_all_vifs();
-    k_stop_dvmrp();
-    igmp_exit();
-#ifndef IOCTL_OK_ON_RAW_SOCKET
-    close(udp_socket);
-#endif
-    did_final_init = 0;
-
-    /*
-     * start processing again
-     */
-    init_genid();
-
-    igmp_init();
-    init_routes();
-    init_ktable();
-    init_vifs();
-    /*XXX Schedule final_init() as main does? */
-    final_init(s);
-
-    /* Touch PID file to acknowledge SIGHUP */
-    pidfile(pid_file);
-
-    /* schedule timer interrupts */
-    timer_set(1, fasttimer, NULL);
-    timer_set(TIMER_INTERVAL, timer, NULL);
+    reload_vifs();
 }
 
 

--- a/src/mroutectl.c
+++ b/src/mroutectl.c
@@ -320,6 +320,7 @@ static int usage(int rc)
 	       "  kill                    Kill running mrouted, like SIGTERM\n"
 	       "  log [? | none | LEVEL]  Set log level: none, err, notice*, info, debug\n"
 	       "  restart                 Restart mrouted and reload .conf file, like SIGHUP\n"
+	       "  reload ifaces           Reload listening interfaces\n"
 	       "  show version            Show version, and uptime (-d), of running mrouted\n"
 	       "  show status             Show status summary, default\n"
 	       "  show compat             Show status, compat mode, previously `mrouted -r`\n"
@@ -416,13 +417,18 @@ int main(int argc, char *argv[])
 		{ "version",    NULL, NULL,         IPC_VERSION_CMD         },
 		{ NULL, NULL, NULL, 0 }
 	};
+	struct cmd reload[] = {
+		{ "ifaces",     NULL, NULL,         IPC_RELOAD_IFACE_CMD    },
+		{ NULL, NULL, NULL, 0 }
+	};
 	struct cmd command[] = {
-		{ "debug",      NULL, set_debug,    0                       },
-		{ "help",       NULL, help,         0                       },
-		{ "kill",       NULL, NULL,         IPC_KILL_CMD            },
-		{ "log",        NULL, set_loglevel, 0                       },
-		{ "restart",    NULL, NULL,         IPC_RESTART_CMD         },
-		{ "show",       show, show_status,  0                       },
+		{ "debug",      NULL,   set_debug,    0                     },
+		{ "help",       NULL,   help,         0                     },
+		{ "kill",       NULL,   NULL,         IPC_KILL_CMD          },
+		{ "log",        NULL,   set_loglevel, 0                     },
+		{ "restart",    NULL,   NULL,         IPC_RESTART_CMD       },
+		{ "show",       show,   show_status,  0                     },
+		{ "reload",     reload, NULL,         0                     },
 		{ NULL, NULL, NULL, 0 }
 	};
 	int c;

--- a/src/route.c
+++ b/src/route.c
@@ -163,6 +163,17 @@ void delete_vif_from_routes(vifi_t vifi)
 }
 
 
+void discard_vif_from_routes(vifi_t vifi)
+{
+    struct rtentry *r, *tmp;
+
+    TAILQ_FOREACH_SAFE(r, &rtable, rt_link, tmp) {
+		if (r->rt_parent == vifi || VIFM_ISSET(vifi, r->rt_children))
+            discard_route(r);
+    }
+}
+
+
 /*
  * A new neighbor has come up.  If we're flooding on the neighbor's
  * vif, mark that neighbor as subordinate for all routes whose parent
@@ -324,7 +335,6 @@ static void create_route(uint32_t origin, uint32_t mask)
     rtp = rt;
     ++nroutes;
 }
-
 
 /*
  * Discard the routing table entry following the one to which 'rt' points.

--- a/src/vif.c
+++ b/src/vif.c
@@ -38,8 +38,8 @@ static int dvmrp_timerid = -1;
 /*
  * Forward declarations.
  */
-void start_vif          (vifi_t vifi);
-static void start_vif2  (vifi_t vifi);
+static void start_vif   (vifi_t vifi);
+void start_vif2         (vifi_t vifi);
 void stop_vif           (vifi_t vifi);
 
 static void send_probe_on_vif  (struct uvif *v);
@@ -477,7 +477,7 @@ static void send_query(struct uvif *v, uint32_t dst, int code, uint32_t group)
 /*
  * Add a vifi to the kernel and start routing on it.
  */
-void start_vif(vifi_t vifi)
+static void start_vif(vifi_t vifi)
 {
     struct uvif *uv;
 
@@ -496,7 +496,7 @@ void start_vif(vifi_t vifi)
  * Add a vifi to all the user-level data structures but don't add
  * it to the kernel yet.
  */
-static void start_vif2(vifi_t vifi)
+void start_vif2(vifi_t vifi)
 {
     struct listaddr *a;
     struct phaddr *p;
@@ -637,6 +637,7 @@ void stop_vif(vifi_t vifi)
      * Update the existing route entries to take into account the vif failure.
      */
     delete_vif_from_routes(vifi);
+    discard_vif_from_routes(vifi);
 
     /*
      * Delete the interface from the kernel's vif structure.

--- a/src/vif.c
+++ b/src/vif.c
@@ -238,27 +238,20 @@ void blaster_free(struct uvif *uv)
 	uv->uv_blastertimer = timer_clear(uv->uv_blastertimer);
 }
 
-/*
- * Start routing on all virtual interfaces that are not down or
- * administratively disabled.
- */
-void init_installvifs(void)
-{
-    struct listaddr *al, *tmp;
-    struct uvif *uv;
-    vifi_t vifi;
 
-    logit(LOG_INFO, 0, "Installing vifs in kernel ...");
-    UVIF_FOREACH(vifi, uv) {
+void init_installvif(struct uvif *uv, vifi_t vifi)
+{
+	struct listaddr *al, *tmp;
+
 	if (uv->uv_flags & VIFF_DISABLED) {
 	    logit(LOG_DEBUG, 0, "%s is disabled", uv->uv_name);
-	    continue;
+	    return;
 	}
 
 	if (uv->uv_flags & VIFF_DOWN) {
 	    logit(LOG_INFO, 0, "%s is not yet up; vif #%u not in service",
 		  uv->uv_name, vifi);
-	    continue;
+	    return;
 	}
 
 	if (uv->uv_flags & VIFF_TUNNEL) {
@@ -285,6 +278,20 @@ void init_installvifs(void)
 	    update_lclgrp(vifi, group);
 	    chkgrp_graft(vifi, group);
 	}
+}
+
+/*
+ * Start routing on all virtual interfaces that are not down or
+ * administratively disabled.
+ */
+void init_installvifs(void)
+{
+    struct uvif *uv;
+    vifi_t vifi;
+
+    logit(LOG_INFO, 0, "Installing vifs in kernel ...");
+    UVIF_FOREACH(vifi, uv) {
+        init_installvif(uv, vifi);
     }
 }
 


### PR DESCRIPTION
**Summary**

This pull request introduces a new feature to the mrouted daemon, allowing users to manually reload the daemon (via mroutectl) in cases where new network interfaces, either virtual or physical, are hotplugged. This reload command functions similarly to the existing restart command, with the key difference being that it preserves existing multicast routing rules, making it less disruptive in running network environments.

**Feature Details**

- Manual Reload Capability: Users can now manually trigger a reload in mrouted when a new network interface is added, without losing any established multicast rules.

- Non-Destructive Behavior: Unlike a full restart, this reload retains the daemon’s knowledge of active routes and existing rules, allowing for seamless integration of new interfaces.
 
- Tested with mcjoin: The feature was validated using mcjoin on a dynamic mesh topology with at least 10 nodes running mrouted, ensuring robustness in dynamic, high-node environments.

**Testing and Validation**

- Test setup with changing (virtual) mesh topology of 10 nodes.
- Validated behavior with mcjoin to ensure multicast traffic was managed correctly during manual reloads.

-----

**Not In Scope:** This change does not automate the reload when interfaces are hotplugged. In future versions, the reload process could be made automatic via:

- Polling: Periodically checking interfaces every N seconds
- rtnetlink Events: Listening for kernel events using rtnetlink
